### PR TITLE
Order students by name in registration page

### DIFF
--- a/danceschool/core/views.py
+++ b/danceschool/core/views.py
@@ -82,7 +82,7 @@ class EventRegistrationSummaryView(PermissionRequiredMixin, SiteHistoryMixin, De
             'registrations': EventRegistration.objects.filter(
                 event=self.object,
                 cancelled=False
-            ).order_by('customer__last_name', 'customer__first_name'),
+            ).order_by('customer__first_name', 'customer__last_name'),
         }
         context.update(kwargs)
         return super(EventRegistrationSummaryView, self).get_context_data(**context)

--- a/danceschool/core/views.py
+++ b/danceschool/core/views.py
@@ -82,7 +82,7 @@ class EventRegistrationSummaryView(PermissionRequiredMixin, SiteHistoryMixin, De
             'registrations': EventRegistration.objects.filter(
                 event=self.object,
                 cancelled=False
-            ).order_by('registration__customer__user__first_name', 'registration__customer__user__last_name'),
+            ).order_by('customer__last_name', 'customer__first_name'),
         }
         context.update(kwargs)
         return super(EventRegistrationSummaryView, self).get_context_data(**context)


### PR DESCRIPTION
Disclaimer: I don't know what I'm doing 😅 

I've been told the order of customers on the registration page was odd. The SQL was something like:

```sql
SELECT
  "core_eventregistration"."id",
  "core_eventregistration"."registration_id",
  "core_eventregistration"."event_id",
  "core_eventregistration"."customer_id",
  "core_eventregistration"."role_id",
  "core_eventregistration"."price",
  "core_eventregistration"."checkedIn",
  "core_eventregistration"."dropIn",
  "core_eventregistration"."cancelled",
  "core_eventregistration"."data"
FROM "core_eventregistration"
INNER JOIN "core_registration"
  ON ("core_eventregistration"."registration_id" = "core_registration"."id")
INNER JOIN "core_customer"
  ON ("core_registration"."customer_id" = "core_customer"."id")
LEFT OUTER JOIN "auth_user"
  ON ("core_customer"."user_id" = "auth_user"."id")
WHERE ("core_eventregistration"."event_id" = 1
AND "core_eventregistration"."cancelled" = FALSE)
ORDER BY "auth_user"."first_name" ASC, "auth_user"."last_name" ASC;
```


with this change, it'll be:

``` sql
SELECT
  "core_eventregistration"."id",
  "core_eventregistration"."registration_id",
  "core_eventregistration"."event_id",
  "core_eventregistration"."customer_id",
  "core_eventregistration"."role_id",
  "core_eventregistration"."price",
  "core_eventregistration"."checkedIn",
  "core_eventregistration"."dropIn",
  "core_eventregistration"."cancelled",
  "core_eventregistration"."data"
FROM "core_eventregistration"
INNER JOIN "core_customer"
  ON ("core_eventregistration"."customer_id" = "core_customer"."id")
WHERE ("core_eventregistration"."event_id" = 1
AND "core_eventregistration"."cancelled" = FALSE)
ORDER BY "core_customer"."last_name" ASC, "core_customer"."first_name" ASC;
```

Notable differences are: not including `auth_user` (don't think it's relevant?) and sorting on customers directly.