### PR TITLE
Add count per role to registrations page

### DIFF
--- a/danceschool/core/templates/core/view_eventregistrations.html
+++ b/danceschool/core/templates/core/view_eventregistrations.html
@@ -5,11 +5,19 @@
 
 <h3>{{ event.name }}</h3>
 
-<dl>
-	<dt>{% trans "Total Students" %}:</dt><dd>{{ event.numRegistered }}</dd>
-	<dt>{% trans "Location" %}:</dt><dd>{{ event.location.name }}{% if event.room.name %} - {{ event.room.name }}{% endif %}</dd>
-	<dt>{% trans "Time" %}:</dt><dd>{{ event.startTime|date:'l, h:i A' }}</dd>
-	<dt>{% trans "Drop-Ins Permitted" %}:</dt><dd>{{ event.allowDropins|yesno }}</dd>
+<dl class="row">
+	<dt class="col-sm-3">{% trans "Total Students" %}:</dt>
+	<dd class="col-sm-9">{{ event.numRegistered }}</dd>
+	{% if event.availableRoles %}
+		{% for role, total in numRegisteredByRole.items %}
+			<dt class="col-sm-3">{{role}}:</dt>
+			<dd class="col-sm-9">{{total}}</dd>
+		{% endfor %}
+	{% endif %}
+	</dd>
+	<dt class="col-sm-3">{% trans "Location" %}:</dt><dd class="col-sm-9">{{ event.location.name }}{% if event.room.name %} - {{ event.room.name }}{% endif %}</dd>
+	<dt class="col-sm-3">{% trans "Time" %}:</dt><dd class="col-sm-9">{{ event.startTime|date:'l, h:i A' }}</dd>
+	<dt class="col-sm-3">{% trans "Drop-Ins Permitted" %}:</dt><dd class="col-sm-9">{{ event.allowDropins|yesno }}</dd>
 </dl>
 
 {% if 'core.checkin_customers' in perms %}

--- a/danceschool/core/views.py
+++ b/danceschool/core/views.py
@@ -94,15 +94,26 @@ class EventRegistrationSummaryView(PermissionRequiredMixin, SiteHistoryMixin, De
         # the view class registrations page.  set_return_page() is in SiteHistoryMixin.
         self.set_return_page('viewregistrations',_('View Registrations'),event_id=self.object.id)
 
+        registrations = EventRegistration.objects.filter(
+            event=self.object,
+            cancelled=False
+        ).order_by('customer__first_name', 'customer__last_name')
+
+        registrations = list(registrations)
+
         context = {
             'event': self.object,
-            'registrations': EventRegistration.objects.filter(
-                event=self.object,
-                cancelled=False
-            ).order_by('customer__first_name', 'customer__last_name'),
+            'registrations': registrations,
+            'numRegisteredByRole': self._numRegisteredByRole(),
         }
         context.update(kwargs)
         return super(EventRegistrationSummaryView, self).get_context_data(**context)
+
+
+    def _numRegisteredByRole(self):
+        byRole = self.object.numRegisteredByRole
+        del byRole[None]
+        return byRole
 
 
 #################################


### PR DESCRIPTION
Adds number of registrations per dance role to the Registrations page. This was requested in order to see, at a glance, if a given class is balanced.

I also went ahead and changed the layout so the label and the info are on the same line -- it felt more readable and nicer now that there can be more information displayed.

Before:
<img width="1064" alt="before" src="https://user-images.githubusercontent.com/224311/67639028-63e77300-f8c1-11e9-9e05-0b4ff7ba91d5.png">

-----

After:
<img width="1056" alt="after" src="https://user-images.githubusercontent.com/224311/67639033-6b0e8100-f8c1-11e9-9099-87317703d959.png">